### PR TITLE
feat: 마이페이지 구현

### DIFF
--- a/src/api/semgrep.ts
+++ b/src/api/semgrep.ts
@@ -6,7 +6,6 @@ import {
   GetSummaryReportResponse,
   PostFileUploadRequest,
   PostFileUploadResponse,
-  SummaryReport,
 } from '@/types/semgrep';
 
 export const postFileUpload = async (requestData: PostFileUploadRequest) => {

--- a/src/api/semgrep.ts
+++ b/src/api/semgrep.ts
@@ -2,6 +2,7 @@ import generateFormData from '@/utils/generateFormData';
 import { endpoint } from './endpoints';
 import { tokenAxios } from '@/utils/axios';
 import {
+  GetDetailedReportResponse,
   GetSummaryReportResponse,
   PostFileUploadRequest,
   PostFileUploadResponse,
@@ -33,5 +34,14 @@ interface GetSummaryReportParams {
 
 export const getSummaryReport = async ({ scan_id }: GetSummaryReportParams) => {
   const { data } = await tokenAxios.get<GetSummaryReportResponse>(endpoint.semgrep.GET_SUMMARY_REPORT(scan_id));
-  return data.result as SummaryReport;
+  return data.result;
+};
+
+interface GetDetailedReportParams {
+  scan_id: string;
+}
+
+export const getDetailedReport = async ({ scan_id }: GetDetailedReportParams) => {
+  const { data } = await tokenAxios.get<GetDetailedReportResponse>(endpoint.semgrep.GET_SUMMARY_REPORT(scan_id));
+  return data.result;
 };

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,4 +1,5 @@
 import {
+  GetMyFilesResponse,
   GetUserInfoResponse,
   PostLoginRequest,
   PostLoginResponse,
@@ -20,5 +21,10 @@ export const postLogin = async (requestData: PostLoginRequest) => {
 
 export const getUserInfo = async () => {
   const { data } = await tokenAxios.get<GetUserInfoResponse>(endpoint.users.GET_USER_INFO);
+  return data.result;
+};
+
+export const getMyFiles = async () => {
+  const { data } = await tokenAxios.get<GetMyFilesResponse>(endpoint.users.GET_USER_SCAN_HISTORY);
   return data.result;
 };

--- a/src/components/Profile/ProfileTab/styles.ts
+++ b/src/components/Profile/ProfileTab/styles.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 export const ProfileTabContainer = styled.section`
   position: absolute;
+  z-index: ${({ theme }) => theme.zIndex.dropdown};
   top: 4rem;
   right: 0;
 

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,4 +1,5 @@
 import { endpoint } from '@/api/endpoints';
+import { useAuthTokenStore } from '@/stores/useAuthTokenStore';
 import {
   GetUserInfoResponse,
   PostLoginRequest,
@@ -7,6 +8,7 @@ import {
   PostRegisterResponse,
 } from '@/types/users';
 import { http, HttpResponse } from 'msw';
+import { MOCK_MY_FILES } from '../mockData/myFiles';
 
 const baseURL = import.meta.env.VITE_API_URL;
 
@@ -66,7 +68,7 @@ const postLogin = () =>
 
 const getUserProfile = () =>
   http.get(`${baseURL}${endpoint.users.GET_USER_INFO}`, async () => {
-    const token = localStorage.getItem('accessToken');
+    const token = useAuthTokenStore.getState().accessToken;
 
     if (!token) {
       return HttpResponse.json({ error: '토큰 에러' }, { status: 401 });
@@ -84,6 +86,22 @@ const getUserProfile = () =>
     return HttpResponse.json(response, { status: 200 });
   });
 
-const authHandler = [postRegister(), postLogin(), getUserProfile()];
+const getMyFiles = () =>
+  http.get(`${baseURL}${endpoint.users.GET_USER_SCAN_HISTORY}`, async () => {
+    const token = useAuthTokenStore.getState().accessToken;
+
+    if (!token) {
+      return HttpResponse.json({ error: '토큰 에러' }, { status: 401 });
+    }
+
+    const response = {
+      status: 200,
+      message: '파일 목록 조회 성공',
+      result: MOCK_MY_FILES,
+    };
+    return HttpResponse.json(response, { status: 200 });
+  });
+
+const authHandler = [postRegister(), postLogin(), getUserProfile(), getMyFiles()];
 
 export default authHandler;

--- a/src/mocks/handlers/semgrep.ts
+++ b/src/mocks/handlers/semgrep.ts
@@ -19,7 +19,7 @@ const postFileUpload = () =>
   });
 
 const getSummaryReport = () =>
-  http.get(`${baseURL}${endpoint.semgrep.GET_SUMMARY_REPORT(MOCK_SCAN_ID)}`, async () => {
+  http.get(new RegExp(`${baseURL}/summary-report/${MOCK_SCAN_ID}`), async () => {
     return HttpResponse.json({
       status: 200,
       message: '성공',

--- a/src/mocks/mockData/myFiles.ts
+++ b/src/mocks/mockData/myFiles.ts
@@ -1,0 +1,57 @@
+import { MyFilesResult } from '@/types/users';
+
+export const MOCK_MY_FILES: MyFilesResult = {
+  files: [
+    {
+      created_at: new Date('Wed, 07 May 2025 11:08:07 GMT'),
+      download_links: {
+        source_single: 'https://example.com/source_single',
+        source_all: 'https://example.com/source_all',
+        result: 'https://example.com/result',
+        translated_result: 'https://example.com/translated_result',
+        view_summary: 'https://example.com/view_summary',
+        view_result: 'https://example.com/view_result',
+      },
+      email: 'admin@email.com',
+      file_id: 'example_scan_id1',
+      result_file: 'results/example_scan_id/result_file',
+      translated_result_file: 'results/example_scan_id/translated_result_file',
+      file_path: ['uploads/example_scan_id/example_file_1.cpp'],
+    },
+    {
+      created_at: new Date('Wed, 07 May 2025 11:08:07 GMT'),
+      download_links: {
+        source_single: 'https://example.com/source_single',
+        source_all: 'https://example.com/source_all',
+        result: 'https://example.com/result',
+        translated_result: 'https://example.com/translated_result',
+        view_summary: 'https://example.com/view_summary',
+        view_result: 'https://example.com/view_result',
+      },
+      email: 'admin@email.com',
+      file_id: 'example_scan_id2',
+      result_file: 'results/example_scan_id/result_file',
+      translated_result_file: 'results/example_scan_id/translated_result_file',
+      file_path: ['uploads/example_scan_id/example_file_2.cpp'],
+    },
+    {
+      created_at: new Date('Wed, 07 May 2025 11:08:07 GMT'),
+      download_links: {
+        source_single: 'https://example.com/source_single',
+        source_all: 'https://example.com/source_all',
+        result: 'https://example.com/result',
+        translated_result: 'https://example.com/translated_result',
+        view_summary: 'https://example.com/view_summary',
+        view_result: 'https://example.com/view_result',
+      },
+      email: 'admin@email.com',
+      file_id: 'example_scan_id3',
+      result_file: 'results/example_scan_id/result_file',
+      translated_result_file: 'results/example_scan_id/translated_result_file',
+      file_path: ['uploads/example_scan_id/example_file_3.cpp'],
+    },
+  ],
+  files_count: 2,
+  files_list: ['example_file_1.cpp', 'example_file_2.cpp', 'example_file_3.cpp'],
+  user_email: 'admin@email.com',
+};

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -2,13 +2,16 @@ import * as S from './styles';
 import { FaFileCode, FaTimes } from 'react-icons/fa';
 import useFileUpload from './hooks/useFileUpload';
 import UndraggableWrapper from '@/components/common/UndraggableWrapper';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postFileUpload } from '@/api/semgrep';
 import { useNavigate } from 'react-router-dom';
 import { PostFileUploadResult } from '@/types/semgrep';
+import { useAuthTokenStore } from '@/stores/useAuthTokenStore';
 
 const LandingPage = () => {
+  const { accessToken } = useAuthTokenStore();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { files, isDragging, fileInputRef, handleFileInputChange, handleClickFileInput, handleDeleteFile } =
     useFileUpload();
 
@@ -19,7 +22,7 @@ const LandingPage = () => {
     mutationKey: ['fileUpload'],
     onSuccess: (data) => {
       const scanId = (data.result as PostFileUploadResult).scan_id;
-      console.log('File analyze success:', data);
+      if (accessToken) queryClient.invalidateQueries({ queryKey: ['myFiles', accessToken] });
       navigate(`/summary/${scanId}`);
     },
     onError: (error) => {

--- a/src/pages/MyPage/components/ScanHistoryList/index.tsx
+++ b/src/pages/MyPage/components/ScanHistoryList/index.tsx
@@ -32,8 +32,8 @@ const ScanHistoryList = () => {
         const fileNames = parsedFilePath.map((path) => path[path.length - 1]).join(', ');
 
         return (
-          <UndraggableWrapper>
-            <S.ScanHistoryItem key={scan.file_id} onClick={() => handleHistoryItemClick(scan.file_id)}>
+          <UndraggableWrapper key={scan.file_id}>
+            <S.ScanHistoryItem onClick={() => handleHistoryItemClick(scan.file_id)}>
               <S.ScanDate>{new Date(scan.created_at).toLocaleDateString()}</S.ScanDate>
               <S.ScanFileSection>
                 <FaFile size={24} />

--- a/src/pages/MyPage/components/ScanHistoryList/index.tsx
+++ b/src/pages/MyPage/components/ScanHistoryList/index.tsx
@@ -14,7 +14,7 @@ const ScanHistoryList = () => {
     queryKey: ['myFiles', accessToken],
     queryFn: getMyFiles,
     enabled: !!accessToken,
-    staleTime: 60 * 60 * 1000,
+    staleTime: 10 * 60 * 1000,
   });
 
   if (!data) return null;

--- a/src/pages/MyPage/components/ScanHistoryList/index.tsx
+++ b/src/pages/MyPage/components/ScanHistoryList/index.tsx
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import * as S from './styles';
+import { getMyFiles } from '@/api/users';
+import { useAuthTokenStore } from '@/stores/useAuthTokenStore';
+import { FaFile } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom';
+import UndraggableWrapper from '@/components/common/UndraggableWrapper';
+
+const ScanHistoryList = () => {
+  const navigate = useNavigate();
+  const { accessToken } = useAuthTokenStore();
+
+  const { data } = useQuery({
+    queryKey: ['myFiles', accessToken],
+    queryFn: getMyFiles,
+    enabled: !!accessToken,
+    staleTime: 60 * 60 * 1000,
+  });
+
+  if (!data) return null;
+
+  const handleHistoryItemClick = (scanId: string) => {
+    navigate(`/summary/${scanId}`);
+  };
+
+  if (data.files.length === 0) return <S.EmptySection>스캔 기록이 없어요.</S.EmptySection>;
+
+  return (
+    <S.ScanHistoryList>
+      {data.files.map((scan) => {
+        const parsedFilePath = scan.file_path.map((path) => path.split('/'));
+        const fileNames = parsedFilePath.map((path) => path[path.length - 1]).join(', ');
+
+        return (
+          <UndraggableWrapper>
+            <S.ScanHistoryItem key={scan.file_id} onClick={() => handleHistoryItemClick(scan.file_id)}>
+              <S.ScanDate>{new Date(scan.created_at).toLocaleDateString()}</S.ScanDate>
+              <S.ScanFileSection>
+                <FaFile size={24} />
+                <S.ScanFileName>{fileNames}</S.ScanFileName>
+              </S.ScanFileSection>
+            </S.ScanHistoryItem>
+          </UndraggableWrapper>
+        );
+      })}
+    </S.ScanHistoryList>
+  );
+};
+
+export default ScanHistoryList;

--- a/src/pages/MyPage/components/ScanHistoryList/styles.ts
+++ b/src/pages/MyPage/components/ScanHistoryList/styles.ts
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+export const ScanHistoryList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  width: 100%;
+`;
+
+export const EmptySection = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: 15rem;
+  ${({ theme }) => theme.fonts.subtitle};
+  border-radius: 1rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+export const ScanHistoryItem = styled.li`
+  cursor: pointer;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  width: 100%;
+  padding: 2.4rem;
+  border-radius: 1rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray200};
+  }
+`;
+
+export const ScanDate = styled.p`
+  ${({ theme }) => theme.fonts.mediumBody};
+`;
+
+export const ScanFileSection = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+  ${({ theme }) => theme.fonts.mediumBody};
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const ScanFileName = styled.p`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,5 +1,29 @@
+import { useUserInfoStore } from '@/stores/useUserInfoStore';
+import * as S from './styles';
+import Tooltip from '@/components/common/Tooltip';
+import { FaRegQuestionCircle } from 'react-icons/fa';
+import ScanHistoryList from './components/ScanHistoryList';
+
 const MyPage = () => {
-  return <div>마이페이지</div>;
+  const { userInfo } = useUserInfoStore();
+  if (!userInfo) return null;
+
+  return (
+    <S.MyPageContainer>
+      <S.MyPageTitle>마이페이지</S.MyPageTitle>
+      <S.ProfileContainer>
+        <S.Username>{userInfo.username}</S.Username>
+        <S.UserEmail>{userInfo.email}</S.UserEmail>
+      </S.ProfileContainer>
+      <S.ScanHistorySection>
+        <S.ScanHistoryTitle>이전에 스캔한 목록</S.ScanHistoryTitle>
+        <Tooltip message="각 스캔 목록을 클릭하면 요약 레포트로 이동해요." position="bottom">
+          <FaRegQuestionCircle size={20} />
+        </Tooltip>
+      </S.ScanHistorySection>
+      <ScanHistoryList />
+    </S.MyPageContainer>
+  );
 };
 
 export default MyPage;

--- a/src/pages/MyPage/styles.ts
+++ b/src/pages/MyPage/styles.ts
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+
+export const MyPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+
+  width: 100%;
+  height: 100%;
+  padding: 6.4rem 19.2rem;
+`;
+
+export const MyPageTitle = styled.p`
+  ${({ theme }) => theme.fonts.title1};
+`;
+
+export const ProfileContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  padding: 1.6rem;
+  border-radius: 1rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+export const Username = styled.p`
+  ${({ theme }) => theme.fonts.title1};
+`;
+
+export const UserEmail = styled.p`
+  ${({ theme }) => theme.fonts.subtitle};
+`;
+
+export const ScanHistorySection = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+`;
+
+export const ScanHistoryTitle = styled.p`
+  ${({ theme }) => theme.fonts.subtitle};
+`;

--- a/src/pages/SummaryReportPage/index.tsx
+++ b/src/pages/SummaryReportPage/index.tsx
@@ -62,6 +62,7 @@ const SummaryReportPage = () => {
       clone.style.width = `${original.scrollWidth}px`;
       clone.style.height = 'auto';
       clone.style.overflow = 'visible';
+      clone.style.backgroundColor = '#f3f4f6';
 
       // 페이지 body에 붙이기
       document.body.appendChild(clone);

--- a/src/types/semgrep.ts
+++ b/src/types/semgrep.ts
@@ -12,7 +12,7 @@ export interface PostFileUploadResult {
   uploaded_files: string[];
 }
 
-export type PostFileUploadResponse = ApiResponse<PostFileUploadRequest>;
+export type PostFileUploadResponse = ApiResponse<PostFileUploadResult>;
 
 export type GetTotalScanResultResponse = ApiResponse<SemgrepJsonRootObject>;
 

--- a/src/types/semgrep.ts
+++ b/src/types/semgrep.ts
@@ -52,3 +52,30 @@ export interface SummaryReport {
 }
 
 export type GetSummaryReportResponse = ApiResponse<SummaryReport>;
+
+export interface DetailedReport {
+  user_id: string | null;
+  id: string;
+  file: string;
+  location: {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+  };
+  type: string;
+  message: string;
+  severity: Severity;
+  suggestion: string;
+  code_snippet: string;
+  metadata: {
+    cwe: string[];
+    category: string;
+    technology: string[];
+    subcategory: string[];
+    likelihood: string;
+    impact: string;
+    vulnerability_class: string[];
+  };
+  references: string[];
+}
+
+export type GetDetailedReportResponse = ApiResponse<DetailedReport>;

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -25,3 +25,28 @@ export interface TokenResult {
 export type PostLoginResponse = ApiResponse<TokenResult>;
 
 export type GetUserInfoResponse = ApiResponse<UserInfoResult>;
+
+export interface ScanInfo {
+  email: string;
+  file_id: string;
+  file_path: string[];
+  result_file: string;
+  translated_result_file: string;
+  created_at: Date;
+  download_links: {
+    source_single: string;
+    source_all: string;
+    result: string;
+    translated_result: string;
+    view_summary: string;
+    view_result: string;
+  };
+}
+export interface MyFilesResult {
+  user_email: string;
+  files_count: number;
+  files: ScanInfo[];
+  files_list: string[];
+}
+
+export type GetMyFilesResponse = ApiResponse<MyFilesResult>;

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -12,10 +12,10 @@ export const tokenAxios = axios.create({
 });
 
 tokenAxios.interceptors.request.use((config) => {
-  const { accessToken } = useAuthTokenStore();
+  const token = useAuthTokenStore.getState().accessToken;
 
-  if (accessToken) {
-    config.headers['x-access-token'] = accessToken;
+  if (token) {
+    config.headers['x-access-token'] = token;
   }
 
   return config;

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,3 +1,4 @@
+import { useAuthTokenStore } from '@/stores/useAuthTokenStore';
 import axios from 'axios';
 
 export const tokenAxios = axios.create({
@@ -11,10 +12,10 @@ export const tokenAxios = axios.create({
 });
 
 tokenAxios.interceptors.request.use((config) => {
-  const token = localStorage.getItem('accessToken');
+  const { accessToken } = useAuthTokenStore();
 
-  if (token) {
-    config.headers['x-access-token'] = token;
+  if (accessToken) {
+    config.headers['x-access-token'] = accessToken;
   }
 
   return config;


### PR DESCRIPTION
## 이슈번호

<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->

- Closes #13 

## 요약(개요)

<!-- 작업한 내용을 간단하게 설명해주세요. -->

- [x] 마이페이지 구현

## 작업 내용

마이페이지는 로그인 한 사용자의 정보와 이전에 스캔한 목록을 함께 보여줍니다.

![image](https://github.com/user-attachments/assets/9b16e1ac-8e94-4d78-8aac-8f3024c32922)
▲ 스캔한 목록이 없는 경우

![image](https://github.com/user-attachments/assets/0be9d1f6-57e8-4548-881d-e7adbe414a98)
▲ 스캔한 목록이 있는 경우. 

스캔한 목록이 있는 경우, 각 아이템을 클릭하면 해당하는 요약 레포트 페이지로 이동합니다.

스캔한 목록 요청 query의 경우, 랜딩 페이지에서 스캔 성공 시 무효화됩니다. 따라서 staleTime이 기본 10분으로 유지되는 동안 새로운 스캔이 들어오면 쿼리를 무효화 하여 새로운 데이터를 받을 수 있도록 합니다.

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
