### PR TITLE
feat: 상세 레포트 페이지 구현

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -3,6 +3,7 @@ export const endpoint = {
     POST_FILE_UPLOAD: '/scan',
     GET_TOTAL_REPORT: (scanId: string) => `/scan-result/${scanId}`,
     GET_SUMMARY_REPORT: (scanId: string) => `/summary-report/${scanId}`,
+    GET_DETAILED_REPORT: (scanId: string, fingerprint: string) => `/detail-report/${scanId}?fingerprint=${fingerprint}`,
     GET_DOWNLOAD_SCAN_RESULT: (scanId: string) => `/download-result/${scanId}`,
     GET_DOWNLOAD_SOURCE_CODE: (scanId: string) => `/download-source/${scanId}`,
     GET_DOWNLOAD_ALL_SOURCE_CODE: (scanId: string) => `/download-all-sources/${scanId}`,

--- a/src/api/semgrep.ts
+++ b/src/api/semgrep.ts
@@ -1,4 +1,3 @@
-import generateFormData from '@/utils/generateFormData';
 import { endpoint } from './endpoints';
 import { tokenAxios } from '@/utils/axios';
 import {

--- a/src/api/semgrep.ts
+++ b/src/api/semgrep.ts
@@ -9,7 +9,8 @@ import {
 } from '@/types/semgrep';
 
 export const postFileUpload = async (requestData: PostFileUploadRequest) => {
-  const formData = generateFormData(requestData);
+  const formData = new FormData();
+  requestData.files.forEach((file) => formData.append('source_code', file));
 
   const { data } = await tokenAxios.post<PostFileUploadResponse>(endpoint.semgrep.POST_FILE_UPLOAD, formData, {
     headers: {
@@ -38,9 +39,12 @@ export const getSummaryReport = async ({ scan_id }: GetSummaryReportParams) => {
 
 interface GetDetailedReportParams {
   scan_id: string;
+  fingerprint: string;
 }
 
-export const getDetailedReport = async ({ scan_id }: GetDetailedReportParams) => {
-  const { data } = await tokenAxios.get<GetDetailedReportResponse>(endpoint.semgrep.GET_SUMMARY_REPORT(scan_id));
+export const getDetailedReport = async ({ scan_id, fingerprint }: GetDetailedReportParams) => {
+  const { data } = await tokenAxios.get<GetDetailedReportResponse>(
+    endpoint.semgrep.GET_DETAILED_REPORT(scan_id, fingerprint),
+  );
   return data.result;
 };

--- a/src/components/common/Header/components/LogoutModal/index.tsx
+++ b/src/components/common/Header/components/LogoutModal/index.tsx
@@ -1,0 +1,27 @@
+import AlertModal from '@/components/common/modals/AlertModal';
+import * as S from './styles';
+import { useNavigate } from 'react-router-dom';
+
+const LogoutModal = () => {
+  const navigate = useNavigate();
+
+  const handleNavigateLoginPage = () => {
+    navigate('/login');
+  };
+
+  return (
+    <AlertModal handleClose={handleNavigateLoginPage}>
+      <S.ModalContainer>
+        <S.Content>
+          토큰이 만료되었어요. <br />
+          다시 로그인 해주세요.
+        </S.Content>
+        <S.ConfirmButton styleType="primary" onClick={handleNavigateLoginPage}>
+          확인
+        </S.ConfirmButton>
+      </S.ModalContainer>
+    </AlertModal>
+  );
+};
+
+export default LogoutModal;

--- a/src/components/common/Header/components/LogoutModal/styles.ts
+++ b/src/components/common/Header/components/LogoutModal/styles.ts
@@ -1,0 +1,19 @@
+import Button from '@/components/common/Button';
+import styled from 'styled-components';
+
+export const ModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  width: 100%;
+  height: 100%;
+`;
+
+export const Content = styled.p`
+  ${({ theme }) => theme.fonts.mediumBody};
+`;
+
+export const ConfirmButton = styled(Button)`
+  width: 100%;
+`;

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -8,11 +8,14 @@ import { useAuthTokenStore } from '@/stores/useAuthTokenStore';
 import { getUserInfo } from '@/api/users';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect } from 'react';
+import useModalStore from '@/stores/useModalStore';
+import LogoutModal from './components/LogoutModal';
 
 const Header = () => {
   const navigate = useNavigate();
   const { accessToken } = useAuthTokenStore();
-  const { isAuthenticated, userInfo, setUserInfo } = useUserInfoStore();
+  const { isAuthenticated, userInfo, setUserInfo, clearUserInfo } = useUserInfoStore();
+  const { openModal } = useModalStore();
 
   const { data } = useQuery({
     queryKey: ['userProfile', accessToken],
@@ -29,6 +32,13 @@ const Header = () => {
       });
     }
   }, [data]);
+
+  useEffect(() => {
+    if (accessToken && !data) {
+      clearUserInfo();
+      openModal('alert', <LogoutModal />);
+    }
+  }, [accessToken, data]);
 
   const handleClickLogoIcon = () => {
     navigate('/');

--- a/src/mocks/mockData/summaryReport.ts
+++ b/src/mocks/mockData/summaryReport.ts
@@ -32,7 +32,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 5,
       type: 'type1',
       message: 'message1message1message1message1message1message1',
-      severity: 'critical',
+      severity: 'CRITICAL',
     },
     {
       id: 'vuln2',
@@ -41,7 +41,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 10,
       type: 'type2',
       message: 'message2',
-      severity: 'error',
+      severity: 'ERROR',
     },
     {
       id: 'vuln3',
@@ -51,7 +51,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       type: 'type3',
       message:
         'message3message3message3message3message3message3message3message3message3message3message3message3message3message3message3message3message3',
-      severity: 'warning',
+      severity: 'WARNING',
     },
     {
       id: 'vuln4',
@@ -60,7 +60,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 20,
       type: 'type4',
       message: 'message4message4message4message4message4message4message4message4',
-      severity: 'info',
+      severity: 'INFO',
     },
     {
       id: 'vuln5',
@@ -69,7 +69,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type5',
       message: 'message5message5message5message5message5message5',
-      severity: 'error',
+      severity: 'ERROR',
     },
     {
       id: 'vuln6',
@@ -78,7 +78,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type6',
       message: 'message6message6message6message6message6',
-      severity: 'error',
+      severity: 'ERROR',
     },
     {
       id: 'vuln7',
@@ -87,7 +87,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type7',
       message: 'message7',
-      severity: 'critical',
+      severity: 'CRITICAL',
     },
     {
       id: 'vuln8',
@@ -96,7 +96,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type8',
       message: 'message8',
-      severity: 'critical',
+      severity: 'CRITICAL',
     },
     {
       id: 'vuln9',
@@ -105,7 +105,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type9',
       message: 'message9',
-      severity: 'warning',
+      severity: 'WARNING',
     },
     {
       id: 'vuln10',
@@ -114,7 +114,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type10',
       message: 'message10',
-      severity: 'warning',
+      severity: 'WARNING',
     },
     {
       id: 'vuln11',
@@ -123,7 +123,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type11',
       message: 'message11',
-      severity: 'info',
+      severity: 'INFO',
     },
     {
       id: 'vuln12',
@@ -132,7 +132,7 @@ export const MOCK_SUMMARY_REPORT: SummaryReport = {
       column: 25,
       type: 'type12',
       message: 'message12',
-      severity: 'info',
+      severity: 'INFO',
     },
   ],
 };

--- a/src/pages/DetailedReportPage/hooks/useGetDetailedReport.ts
+++ b/src/pages/DetailedReportPage/hooks/useGetDetailedReport.ts
@@ -1,0 +1,21 @@
+import { getDetailedReport } from '@/api/semgrep';
+import { useQuery } from '@tanstack/react-query';
+
+interface UseGetDetailedReportProps {
+  scanId: string;
+  fingerprintId: string;
+}
+
+const useGetDetailedReport = ({ scanId, fingerprintId }: UseGetDetailedReportProps) => {
+  const { data } = useQuery({
+    queryKey: ['detailedReport', scanId, fingerprintId],
+    queryFn: async () => await getDetailedReport({ scan_id: scanId, fingerprint: fingerprintId }),
+    staleTime: 60 * 60 * 1000,
+  });
+
+  return {
+    data,
+  };
+};
+
+export default useGetDetailedReport;

--- a/src/pages/DetailedReportPage/index.tsx
+++ b/src/pages/DetailedReportPage/index.tsx
@@ -15,10 +15,14 @@ const DetailedReportPage = () => {
   const { data } = useGetDetailedReport({ scanId, fingerprintId: vulnId });
   if (!data) return <DimmedLoadingPage />;
 
+  const handleClickGoBack = () => {
+    navigate(`/summary/${scanId}`);
+  };
+
   return (
     <S.DetailedReportPageContainer>
       <S.GoBackButton>
-        <FaArrowLeft size={32} onClick={() => navigate(-1)} />
+        <FaArrowLeft size={32} onClick={handleClickGoBack} />
       </S.GoBackButton>
       <S.PatternSection>
         <S.SemgrepPatternSection>

--- a/src/pages/DetailedReportPage/index.tsx
+++ b/src/pages/DetailedReportPage/index.tsx
@@ -1,0 +1,75 @@
+import { FaArrowLeft, FaFile, FaRegQuestionCircle } from 'react-icons/fa';
+import * as S from './styles';
+import { useNavigate, useParams } from 'react-router-dom';
+import useGetDetailedReport from './hooks/useGetDetailedReport';
+import DimmedLoadingPage from '../LoadingPage/DimmedLoadingPage';
+import SeverityBadge from '../SummaryReportPage/components/SeverityBadge';
+import { FiTarget } from 'react-icons/fi';
+import Tooltip from '@/components/common/Tooltip';
+
+const DetailedReportPage = () => {
+  const navigate = useNavigate();
+  const { scanId, vulnId } = useParams();
+  if (!scanId || !vulnId) return null;
+
+  const { data } = useGetDetailedReport({ scanId, fingerprintId: vulnId });
+  if (!data) return <DimmedLoadingPage />;
+
+  return (
+    <S.DetailedReportPageContainer>
+      <S.GoBackButton>
+        <FaArrowLeft size={32} onClick={() => navigate(-1)} />
+      </S.GoBackButton>
+      <S.PatternSection>
+        <S.SemgrepPatternSection>
+          <S.SectionHeader>
+            <S.SectionTitle>{'<발견된 취약점 패턴>'}</S.SectionTitle>
+            <Tooltip message="Semgrep에서 발견한 보안 취약점 패턴 설명이에요." position="right">
+              <FaRegQuestionCircle size={20} />
+            </Tooltip>
+          </S.SectionHeader>
+          <S.PatternTitle>{data.type}</S.PatternTitle>
+          <S.ScanResultSection>
+            <SeverityBadge severity={data.severity} />
+            <S.ScannedFile>
+              <FaFile size={24} />
+              <S.ScannedFileName>{data.file}</S.ScannedFileName>
+            </S.ScannedFile>
+            <S.VulnerabilityOrigin>
+              <FiTarget size={24} />
+              <S.VulnerabilityPosition>
+                {`line ${data.location.start.line}, col ${data.location.start.column} ~ line ${data.location.end.line}, col ${data.location.end.column}`}
+              </S.VulnerabilityPosition>
+            </S.VulnerabilityOrigin>
+          </S.ScanResultSection>
+          <S.PatternMessage>{data.message}</S.PatternMessage>
+        </S.SemgrepPatternSection>
+        <S.AdditionalInfoSection>
+          <S.SectionHeader>
+            <S.SectionTitle>{'<패턴 부가 정보>'}</S.SectionTitle>
+            <Tooltip message="CWE 지침서 기반의 보안 취약점 정보를 확인해 보세요." position="right">
+              <FaRegQuestionCircle size={20} />
+            </Tooltip>
+          </S.SectionHeader>
+          <S.PatternTitle>{data.metadata.cwe}</S.PatternTitle>
+          {data.references && (
+            <>
+              <S.ReferenceTitle>참고 자료</S.ReferenceTitle>
+              {data.references.map((reference) => (
+                <S.ReferenceLink key={reference}>
+                  <a href={reference}>{reference}</a>
+                </S.ReferenceLink>
+              ))}
+            </>
+          )}
+        </S.AdditionalInfoSection>
+      </S.PatternSection>
+      <S.SolutionSection>
+        <S.SectionTitle>{'<어떻게 대처하나요?>'}</S.SectionTitle>
+        <S.SolutionMessage>{data.suggestion}</S.SolutionMessage>
+      </S.SolutionSection>
+    </S.DetailedReportPageContainer>
+  );
+};
+
+export default DetailedReportPage;

--- a/src/pages/DetailedReportPage/styles.ts
+++ b/src/pages/DetailedReportPage/styles.ts
@@ -1,0 +1,126 @@
+import styled from 'styled-components';
+
+export const DetailedReportPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  width: 100%;
+  height: 100%;
+  padding: 3.2rem;
+`;
+
+export const GoBackButton = styled.div`
+  display: flex;
+  width: 100%;
+
+  & > * {
+    cursor: pointer;
+  }
+`;
+
+export const PatternSection = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  width: 100%;
+  height: max-content;
+
+  & > div {
+    display: flex;
+    flex-direction: column;
+    gap: 1.6rem;
+
+    padding: 3.2rem;
+    border: 0.1rem solid ${({ theme }) => theme.colors.gray200};
+    border-radius: 1rem;
+
+    background-color: ${({ theme }) => theme.colors.white};
+  }
+`;
+
+export const SemgrepPatternSection = styled.div`
+  width: 100%;
+`;
+
+export const AdditionalInfoSection = styled.div`
+  width: 100%;
+`;
+
+export const SectionHeader = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const SectionTitle = styled.p`
+  ${({ theme }) => theme.fonts.mediumBody};
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const PatternTitle = styled.p`
+  ${({ theme }) => theme.fonts.subtitle};
+`;
+
+export const ScanResultSection = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+  width: 100%;
+`;
+
+export const ScannedFile = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const ScannedFileName = styled.p`
+  ${({ theme }) => theme.fonts.mediumBody};
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+export const VulnerabilityOrigin = styled.div`
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  ${({ theme }) => theme.fonts.mediumBody};
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const VulnerabilityPosition = styled.p`
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+export const PatternMessage = styled.p`
+  ${({ theme }) => theme.fonts.mediumBody};
+`;
+
+export const ReferenceTitle = styled.p`
+  ${({ theme }) => theme.fonts.subtitle};
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const ReferenceLink = styled.li`
+  ${({ theme }) => theme.fonts.mediumBody};
+  text-decoration: none;
+  list-style-type: disc;
+`;
+
+export const SolutionSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  width: 100%;
+  padding: 3.2rem;
+  border: 0.1rem solid ${({ theme }) => theme.colors.gray200};
+  border-radius: 1rem;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+export const SolutionMessage = styled.p`
+  ${({ theme }) => theme.fonts.mediumBody};
+`;

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -21,7 +21,7 @@ const LandingPage = () => {
     },
     mutationKey: ['fileUpload'],
     onSuccess: (data) => {
-      const scanId = (data.result as PostFileUploadResult).scan_id;
+      const scanId = (data.result as PostFileUploadResult).file_id;
       if (accessToken) queryClient.invalidateQueries({ queryKey: ['myFiles', accessToken] });
       navigate(`/summary/${scanId}`);
     },

--- a/src/pages/MyPage/components/ScanHistoryList/index.tsx
+++ b/src/pages/MyPage/components/ScanHistoryList/index.tsx
@@ -28,7 +28,7 @@ const ScanHistoryList = () => {
   return (
     <S.ScanHistoryList>
       {data.files.map((scan) => {
-        const parsedFilePath = scan.file_path.map((path) => path.split('/'));
+        const parsedFilePath = scan.file_paths.map((path) => path.split('\\'));
         const fileNames = parsedFilePath.map((path) => path[path.length - 1]).join(', ');
 
         return (

--- a/src/pages/SummaryReportPage/components/SeverityBadge/styles.ts
+++ b/src/pages/SummaryReportPage/components/SeverityBadge/styles.ts
@@ -13,13 +13,13 @@ export const SeverityBadgeContainer = styled.div<{ $severity: Severity }>`
 
   color: ${({ theme, $severity }) => {
     switch ($severity) {
-      case 'critical':
+      case 'CRITICAL':
         return theme.colors.white;
-      case 'error':
+      case 'ERROR':
         return theme.colors.white;
-      case 'warning':
+      case 'WARNING':
         return theme.colors.black;
-      case 'info':
+      case 'INFO':
         return theme.colors.black;
       default:
         return theme.colors.white;
@@ -28,13 +28,13 @@ export const SeverityBadgeContainer = styled.div<{ $severity: Severity }>`
 
   background-color: ${({ theme, $severity }) => {
     switch ($severity) {
-      case 'critical':
+      case 'CRITICAL':
         return theme.colors.severity_critial;
-      case 'error':
+      case 'ERROR':
         return theme.colors.severity_error;
-      case 'warning':
+      case 'WARNING':
         return theme.colors.severity_warning;
-      case 'info':
+      case 'INFO':
         return theme.colors.severity_info;
       default:
         return theme.colors.black;

--- a/src/pages/SummaryReportPage/components/SeverityChart/index.tsx
+++ b/src/pages/SummaryReportPage/components/SeverityChart/index.tsx
@@ -50,7 +50,12 @@ const SeverityChart = ({ contents }: SeverityChartProps) => {
             const labelY = 80 + RADIUS * Math.sin(radians);
 
             // 항목이 차지하는 각도가 임계치보다 작으면 count만 표시
-            const labelText = angle < MIN_ANGLE_FOR_FULL_LABEL ? `${item.count}` : `${item.severity}, ${item.count}`;
+            const labelText =
+              angle < MIN_ANGLE_FOR_FULL_LABEL
+                ? item.count === 0
+                  ? ''
+                  : `${item.count}`
+                : `${item.severity}, ${item.count}`;
 
             return (
               <g key={index}>
@@ -68,7 +73,7 @@ const SeverityChart = ({ contents }: SeverityChartProps) => {
                   x={labelX}
                   y={labelY}
                   fontSize="10"
-                  fill={item.severity === 'critical' || item.severity === 'error' ? 'white' : 'black'}
+                  fill={item.severity === 'CRITICAL' || item.severity === 'ERROR' ? 'white' : 'black'}
                   textAnchor="middle"
                   alignmentBaseline="middle"
                   transform={`rotate(90, ${labelX}, ${labelY})`}

--- a/src/pages/SummaryReportPage/components/VulnerabilityItem/index.tsx
+++ b/src/pages/SummaryReportPage/components/VulnerabilityItem/index.tsx
@@ -11,11 +11,12 @@ interface VulnerabilityItemProps {
   column: number;
   message: string;
   severity: Severity;
+  handleClick: () => void;
 }
 
-const VulnerabilityItem = ({ file, line, column, message, severity }: VulnerabilityItemProps) => {
+const VulnerabilityItem = ({ file, line, column, message, severity, handleClick }: VulnerabilityItemProps) => {
   return (
-    <S.VulnerabilityItemContainer>
+    <S.VulnerabilityItemContainer onClick={handleClick}>
       <S.SeverityColorBar $severity={severity} />
       <S.VulnerabilityItemContent>
         <S.VulnerabilityInfoContainer>

--- a/src/pages/SummaryReportPage/components/VulnerabilityItem/styles.ts
+++ b/src/pages/SummaryReportPage/components/VulnerabilityItem/styles.ts
@@ -16,13 +16,13 @@ export const SeverityColorBar = styled.div<{ $severity: Severity }>`
   border-bottom: 0.1rem solid ${({ theme }) => theme.colors.white};
   background-color: ${({ theme, $severity }) => {
     switch ($severity) {
-      case 'critical':
+      case 'CRITICAL':
         return theme.colors.severity_critial;
-      case 'error':
+      case 'ERROR':
         return theme.colors.severity_error;
-      case 'warning':
+      case 'WARNING':
         return theme.colors.severity_warning;
-      case 'info':
+      case 'INFO':
         return theme.colors.severity_info;
       default:
         return theme.colors.black;

--- a/src/pages/SummaryReportPage/components/VulnerabilityList/index.tsx
+++ b/src/pages/SummaryReportPage/components/VulnerabilityList/index.tsx
@@ -1,12 +1,19 @@
 import { Vulnerability } from '@/types/semgrep';
 import * as S from './styles';
 import VulnerabilityItem from '../VulnerabilityItem';
+import { useNavigate } from 'react-router-dom';
 
 interface VulnerabilityProps {
   data: Vulnerability[][];
 }
 
 const VulnerabilityList = ({ data }: VulnerabilityProps) => {
+  const navigate = useNavigate();
+
+  const handleItemClick = (vulnId: string) => {
+    navigate(vulnId);
+  };
+
   return (
     <S.VulnerabilityListContainer>
       {data
@@ -21,6 +28,7 @@ const VulnerabilityList = ({ data }: VulnerabilityProps) => {
                 column={vuln.column}
                 message={vuln.message}
                 severity={vuln.severity}
+                handleClick={() => handleItemClick(vuln.id)}
               />
             ))}
           </S.VulnerabilityList>

--- a/src/pages/SummaryReportPage/components/VulnerabilityList/index.tsx
+++ b/src/pages/SummaryReportPage/components/VulnerabilityList/index.tsx
@@ -12,9 +12,9 @@ const VulnerabilityList = ({ data }: VulnerabilityProps) => {
       {data.map((group, idx) => {
         return (
           <S.VulnerabilityList key={`severity_${idx}`}>
-            {group.map((vuln) => (
+            {group.map((vuln, idx) => (
               <VulnerabilityItem
-                key={vuln.id}
+                key={`${vuln.id}_${idx}`}
                 file={vuln.file}
                 line={vuln.line}
                 column={vuln.column}

--- a/src/pages/SummaryReportPage/components/VulnerabilityList/index.tsx
+++ b/src/pages/SummaryReportPage/components/VulnerabilityList/index.tsx
@@ -9,12 +9,13 @@ interface VulnerabilityProps {
 const VulnerabilityList = ({ data }: VulnerabilityProps) => {
   return (
     <S.VulnerabilityListContainer>
-      {data.map((group, idx) => {
-        return (
+      {data
+        .filter((group) => group.length > 0)
+        .map((group, idx) => (
           <S.VulnerabilityList key={`severity_${idx}`}>
-            {group.map((vuln, idx) => (
+            {group.map((vuln, itemIdx) => (
               <VulnerabilityItem
-                key={`${vuln.id}_${idx}`}
+                key={`${vuln.id}_${itemIdx}`}
                 file={vuln.file}
                 line={vuln.line}
                 column={vuln.column}
@@ -23,8 +24,7 @@ const VulnerabilityList = ({ data }: VulnerabilityProps) => {
               />
             ))}
           </S.VulnerabilityList>
-        );
-      })}
+        ))}
     </S.VulnerabilityListContainer>
   );
 };

--- a/src/pages/SummaryReportPage/hooks/useGetSummaryReport.ts
+++ b/src/pages/SummaryReportPage/hooks/useGetSummaryReport.ts
@@ -7,7 +7,7 @@ interface UseGetSummaryReportProps {
 
 const useGetSummaryReport = ({ scanId }: UseGetSummaryReportProps) => {
   const { data: summaryReport } = useQuery({
-    queryKey: ['summaryReport'],
+    queryKey: ['summaryReport', scanId],
     queryFn: async () => await getSummaryReport({ scan_id: scanId }),
     staleTime: 60 * 60 * 1000,
   });

--- a/src/pages/SummaryReportPage/hooks/useSummaryReportData.ts
+++ b/src/pages/SummaryReportPage/hooks/useSummaryReportData.ts
@@ -14,7 +14,7 @@ const useFilterSummaryReport = ({ summaryReport }: UseFilterSummaryReport) => {
   });
 
   // 심각도별 보기 정렬
-  const severityOrder: Severity[] = ['critical', 'error', 'warning', 'info'];
+  const severityOrder: Severity[] = ['CRITICAL', 'ERROR', 'WARNING', 'INFO'];
   const groupedBySeverity = severityOrder.map((severity) =>
     summaryReport.vulnerabilities.filter((vuln) => vuln.severity === severity),
   );

--- a/src/pages/SummaryReportPage/index.tsx
+++ b/src/pages/SummaryReportPage/index.tsx
@@ -14,6 +14,7 @@ import { Vulnerability } from '@/types/semgrep';
 import VulnerabilityList from './components/VulnerabilityList';
 import html2canvas from 'html2canvas';
 import { saveAs } from 'file-saver';
+import DimmedLoadingPage from '../LoadingPage/DimmedLoadingPage';
 
 export type VulnerabilityFilter = 'groupBySeverity' | 'groupByType';
 
@@ -32,7 +33,7 @@ const SummaryReportPage = () => {
   if (!scanId) return null;
 
   const { summaryReport } = useGetSummaryReport({ scanId });
-  if (!summaryReport) return null;
+  if (!summaryReport) return <DimmedLoadingPage />;
 
   const { fileVulnerabilities, groupedBySeverity, groupedByType, severityChartData } = useFilterSummaryReport({
     summaryReport,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -11,6 +11,7 @@ import ErrorPage from './pages/ErrorPage';
 import { Suspense } from 'react';
 import DimmedLoadingPage from './pages/LoadingPage/DimmedLoadingPage';
 import ModalRenderer from './components/common/ModalRenderer';
+import DetailedReportPage from './pages/DetailedReportPage';
 
 const router = createBrowserRouter([
   {
@@ -27,6 +28,7 @@ const router = createBrowserRouter([
       { index: true, element: <LandingPage /> },
       { path: '/introduction', element: <IntroductionPage /> },
       { path: '/summary/:scanId', element: <SummaryReportPage /> },
+      { path: '/summary/:scanId/:vulnId', element: <DetailedReportPage /> },
 
       // 로그인 안 한 사용자만 접근 가능한 페이지
       {

--- a/src/types/semgrep.ts
+++ b/src/types/semgrep.ts
@@ -16,13 +16,13 @@ export type PostFileUploadResponse = ApiResponse<PostFileUploadResult>;
 
 export type GetTotalScanResultResponse = ApiResponse<SemgrepJsonRootObject>;
 
-export type Severity = 'critical' | 'error' | 'warning' | 'info';
+export type Severity = 'CRITICAL' | 'ERROR' | 'WARNING' | 'INFO';
 
 export const getSeverityColors = (): Record<Severity, CSSProperties['color']> => ({
-  critical: theme.colors.severity_critial,
-  error: theme.colors.severity_error,
-  warning: theme.colors.severity_warning,
-  info: theme.colors.severity_info,
+  CRITICAL: theme.colors.severity_critial,
+  ERROR: theme.colors.severity_error,
+  WARNING: theme.colors.severity_warning,
+  INFO: theme.colors.severity_info,
 });
 
 interface SeveritySummary {

--- a/src/types/semgrep.ts
+++ b/src/types/semgrep.ts
@@ -4,11 +4,11 @@ import theme from '@/styles/theme';
 import { ApiResponse } from './common';
 
 export interface PostFileUploadRequest {
-  files: File[];
+  files: Blob[];
 }
 
 export interface PostFileUploadResult {
-  scan_id: string;
+  file_id: string;
   uploaded_files: string[];
 }
 

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -29,17 +29,19 @@ export type GetUserInfoResponse = ApiResponse<UserInfoResult>;
 export interface ScanInfo {
   email: string;
   file_id: string;
-  file_path: string[];
+  file_paths: string[];
   result_file: string;
   translated_result_file: string;
+  uploaded_file_id: string;
   created_at: Date;
   download_links: {
-    source_single: string;
-    source_all: string;
     result: string;
+    source_all: string;
+    source_single: string;
     translated_result: string;
-    view_summary: string;
+    view_detail: string; // TODO: 수정 예정
     view_result: string;
+    view_summary: string;
   };
 }
 export interface MyFilesResult {

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 export const tokenAxios = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  timeout: 15000,
+  timeout: 60 * 60 * 1000,
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -22,7 +22,7 @@ tokenAxios.interceptors.request.use((config) => {
 
 export const publicAxios = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
-  timeout: 15000,
+  timeout: 60 * 60 * 1000,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -7,7 +7,6 @@ export const tokenAxios = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Credentials': 'true',
   },
 });
 


### PR DESCRIPTION
## 이슈번호

<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->

- Closes #15 

## 요약(개요)

<!-- 작업한 내용을 간단하게 설명해주세요. -->

- [x] 상세 레포트 페이지 구현
- [x] accessToken 만료 시 모달이 뜨면서 다시 로그인 하도록 유도
- [x] 기타 동작 오류 수정

## 작업 내용

로컬에서 서버를 직접 돌려보면서 전반적인 동작에서 발생하는 오류들을 수정했습니다 (api 응답 객체 구조 통일, 누락된 속성 추가 등).

### 상세 페이지 구현 
요약 페이지에서 각 취약점 아이템을 클릭하면 상세 페이지로 이동합니다.
상세 페이지에서 왼쪽 화살표 버튼을 누르면 다시 요약 페이지로 이동합니다.

![image](https://github.com/user-attachments/assets/109da31b-0716-4ffd-9255-e6820e794abb)


상세 페이지에서는 크게 다음과 같은 정보를 포함합니다.

- Semgrep에서 발견한 취약점 패턴 관련 설명
- CWE 기반의 취약점 패턴 설명 및 참고 자료(하이퍼링크)
- 해결을 위한 솔루션 제공

이 중 솔루션 제공 부분은 현재는 Semgrep의 패턴 설명과 동일하지만, 추후 AI를 사용하게 되면 풍부해집니다.

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
